### PR TITLE
FIX Reindex fails if Versioned DataObject has no own table

### DIFF
--- a/code/tasks/SolrReindexTask.php
+++ b/code/tasks/SolrReindexTask.php
@@ -66,7 +66,8 @@ class SolrReindexTask extends BuildTask
 					if ($page->hasExtension('Versioned')) {
 						$search->index($page, 'Stage');
 						
-						$live = Versioned::get_one_by_stage($page->ClassName, 'Live', "\"$page->ClassName\".\"ID\" = $page->ID");
+						$baseTable = $page->baseTable();
+						$live = Versioned::get_one_by_stage($page->ClassName, 'Live', "\"$baseTable\".\"ID\" = $page->ID");
 						if ($live) {
 							$search->index($live, 'Live');
 							echo "<p>Reindexed Live version of $live->Title</p>\n";


### PR DESCRIPTION
If an DataObject extends an other DataObject without adding new dbfields, it will not have it's own table in the database. The sql query would break, since `$page->ClassName.ID` does not exist in the db.
