### PR TITLE
updated framework/cms dependency constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
 	],
 	"require":
 	{
-		"silverstripe/framework": "3.1.x-dev",
-		"silverstripe/cms": "3.1.x-dev",
+		"silverstripe/framework": "~3.1",
+		"silverstripe/cms": "~3.1",
 		"silverstripe/multivaluefield": "dev-master"
 	}
 }


### PR DESCRIPTION
updated framework/cms dependency constraints. was not accepting 3.1.0 stable
