### PR TITLE
BUGFIX check if a $db's datatype has parameters eg. Varchar(255)

### DIFF
--- a/code/pages/SolrSearchPage.php
+++ b/code/pages/SolrSearchPage.php
@@ -249,6 +249,7 @@ class SolrSearchPage extends Page {
 			foreach ($listType as $classType) {
 				$db = Config::inst()->get($classType, 'db');
 				foreach ($db as $name => $type) {
+					$type = current(explode("(", $type));
 					if (is_subclass_of($type, 'SolrGeoPoint') || $type == 'SolrGeoPoint') {
 						unset($objFields[$name]);
 					}


### PR DESCRIPTION
Was breaking with fields that have Varchar(255) etc
