### PR TITLE
BUGFIX: Change year format from o to Y to stop weeks that overlap years getting the wrong year

### DIFF
--- a/code/service/SolrSearchService.php
+++ b/code/service/SolrSearchService.php
@@ -978,19 +978,22 @@ class SolrSchemaMapper {
 			return $newReturn;
 		} else {
 			switch ($type) {
+				case 'Date':
 				case 'SS_Datetime': {
 						// we don't want a complete iso8601 date, we want it 
 						// in UTC time with a Z at the end. It's okay, php's
 						// strtotime will correctly re-convert this to the correct
-						// timestamp, but this is how Solr wants things
-						$hoursToRemove = date('Z');
-						$ts = strtotime($value) - $hoursToRemove;
-
-						return date('o-m-d\TH:i:s\Z', $ts);
-					}
+						// timestamp, but this is how Solr wants things.
+						// If we don't have a full DateTime stamp we won't remove any hours
+						$hoursToRemove = (strlen($value) == 10) ? 0 : date('Z');
+						$ts = strtotime($value);
+						$tsHTR = $ts - $hoursToRemove;
+						$date = date('Y-m-d\TH:i:s\Z', $tsHTR);
+						return $date;
+				}
 				case 'HTMLText': {
 						return strip_tags($value);
-					}
+				}
 				case 'SolrGeoPoint': {
 					return $value->y . ',' . $value->x;
 				}


### PR DESCRIPTION
And allow passing of Date fields that lack timestamps
