### PR TITLE
Reset content type for Get+Head requests for reused curl connection

### DIFF
--- a/code/thirdparty/Apache/Solr/HttpTransport/Curl.php
+++ b/code/thirdparty/Apache/Solr/HttpTransport/Curl.php
@@ -119,6 +119,9 @@ class Apache_Solr_HttpTransport_Curl extends Apache_Solr_HttpTransport_Abstract
 			// set the URL
 			CURLOPT_URL => $url,
 
+			// set the content type to blank
+			CURLOPT_HTTPHEADER => array(),
+
 			// set the timeout
 			CURLOPT_TIMEOUT => $timeout
 		));
@@ -149,6 +152,9 @@ class Apache_Solr_HttpTransport_Curl extends Apache_Solr_HttpTransport_Abstract
 
 			// set the URL
 			CURLOPT_URL => $url,
+
+			// set the content type to blank
+			CURLOPT_HTTPHEADER => array(),
 
 			// set the timeout
 			CURLOPT_TIMEOUT => $timeout


### PR DESCRIPTION
This is a fix for Solr v5.3.1 when reusing a curl connection; if a GET or HEAD request contains a content type header Solr throws an error (this could be added by a previous POST request )
