### PR TITLE
fix(SolrSearch): Changed default search type from 'Page' to 'SiteTree'

### DIFF
--- a/code/extensions/SolrSearch.php
+++ b/code/extensions/SolrSearch.php
@@ -72,6 +72,13 @@ if(class_exists('ExtensibleSearchPage')) {
 		 */
 		public static $filter_param = 'filter';
 
+		/**
+		 * The default classes to search on.
+		 *
+		 * @var array
+		 */
+		private static $default_searchable_types = array('SiteTree');
+
 		public static $dependencies = array(
 			'solrSearchService'			=> '%$SolrSearchService',
 		);
@@ -212,7 +219,7 @@ if(class_exists('ExtensibleSearchPage')) {
 			// overly much
 			if (!count($types) && $sortBy) {
 				// default to page
-				$types = array('Page');
+				$types = Config::inst()->get(__CLASS__, 'default_searchable_types');
 			}
 
 			if (!isset($fields[$sortBy])) {

--- a/code/service/SolrSearchService.php
+++ b/code/service/SolrSearchService.php
@@ -703,12 +703,15 @@ class SolrSearchService {
 	 * @param String $field
 	 * 				The field name to get the Solr type for.
 	 * @param String $classNames
-	 * 				A list of data object class name. Defaults to 'page'. 
+	 * 				A list of data object class name.
 	 *
 	 * @return String
 	 *
 	 */
-	public function getSolrFieldName($field, $classNames = array('Page')) {
+	public function getSolrFieldName($field, $classNames = null) {
+		if (!$classNames) {
+			$classNames = Config::inst()->get('SolrSearch', 'default_searchable_types');
+		}
 		if (!is_array($classNames)) {
 			$classNames = array($classNames);
 		}
@@ -740,10 +743,7 @@ class SolrSearchService {
 	 * @param String $classNames
 	 * 				A list of potential class types that the field may exist in (ie if searching in multiple types)
 	 */
-	public function getSortFieldName($field, $classNames = array('Page')) {
-		if (!is_array($classNames)) {
-			$classNames = array($classNames);
-		}
+	public function getSortFieldName($field, $classNames = null) {
 		return $this->getSolrFieldName($field, $classNames);
 	}
 


### PR DESCRIPTION
Changed default search type from 'Page' to 'SiteTree' to fix a bug with Mediawesome, as its MediaPage class extends SiteTree, rather than Page. Made the default search type configurable as well.

PLEASE ALSO: Make a 4 or 4.1 branch and do the PR on that too.

NOTE: There are a couple of calls to 'searchableTypes' that pass in 'Page' and may need to be factored in the future to work with this config. I only changed the default 'Page' value for functions that were within the 'getQuery' code path as that is all that's been tested.
