### PR TITLE
Remove Content-Type from Curl GET Request

### DIFF
--- a/code/thirdparty/Apache/Solr/HttpTransport/Curl.php
+++ b/code/thirdparty/Apache/Solr/HttpTransport/Curl.php
@@ -119,6 +119,9 @@ class Apache_Solr_HttpTransport_Curl extends Apache_Solr_HttpTransport_Abstract
 			// set the URL
 			CURLOPT_URL => $url,
 
+			// unset the content type, could be left over from previous request
+			CURLOPT_HTTPHEADER => array("Content-Type:"),
+
 			// set the timeout
 			CURLOPT_TIMEOUT => $timeout
 		));


### PR DESCRIPTION
Of course, the curl problem with content-type headers fixed in #51 also affects get requests.

Solr 5.1 does not like Content-Types on GET requests.
The Curl HttpTransport reuses the curl instance if you send multiple requests to Solr. This leads to an error if you send a post request, which sets the Content-Type Header and then send a GET request like search.