### PR TITLE
Fix Reindex job failing DataObject::get() on classes that don't implement $db

### DIFF
--- a/code/tasks/SolrReindexJob.php
+++ b/code/tasks/SolrReindexJob.php
@@ -40,7 +40,8 @@ if (class_exists('AbstractQueuedJob')) {
 				Subsite::disable_subsite_filter();
 			}
 
-			$pages = DataObject::get($this->reindexType, '"' . $this->reindexType.'"."ID" > ' . $this->lastIndexedID, 'ID ASC', '', '0, ' . self::$at_a_time);
+			$class = $this->reindexType;
+			$pages = $class::get()->filter('ID:GreaterThan', $this->lastIndexedID)->sort('ID ASC')->limit('0, ' . self::$at_a_time);
 			
 			if (ClassInfo::exists('Subsite')) {
 				Subsite::$disable_subsite_filter = false;


### PR DESCRIPTION
If a class doesn't implement `$db` the
`DataObject::get('ClassName', 'ClassName.ID'...`
fails as SilverStripe doesn't create an SQL table for the class instead using
the parent class' SQL table