### PR TITLE
FIX, when a base query is set to nothing, it should be doing a select…

### DIFF
--- a/code/service/querybuilders/SolrQueryBuilder.php
+++ b/code/service/querybuilders/SolrQueryBuilder.php
@@ -66,7 +66,7 @@ class SolrQueryBuilder {
 	protected $facetCount = 1;
 
 	public function baseQuery($query) {
-		$this->userQuery = $query;
+		$this->userQuery = $query ?: '*:*';
 		return $this;
 	}
 	

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "5.3.x-dev"
+			"dev-master": "6.0.x-dev"
 		}
 	}
 }


### PR DESCRIPTION
… all.

Should a base query somehow be set to nothing, my assumption is that it should just do a `*:*` query. However this is not the case, and it just gives you an empty result set. Obviously it shouldn't be set to nothing in the first place, but I feel that this would capture the problem regardless of what's causing it. I know that an older version of the module had a default search, but that has since been removed.